### PR TITLE
add xtra_cluster_ips option to manually add IPs to the cluster array

### DIFF
--- a/jobs/arbitrator/spec
+++ b/jobs/arbitrator/spec
@@ -44,3 +44,8 @@ properties:
   cf_mysql.mysql.galera_healthcheck.port:
     description: 'Port used by sidecar process to listen on'
     default: 9200
+  cf_mysql.mysql.xtra_cluster_ips:
+    description: 'additional cluster IPs that are not part of the deployment'
+    example: |
+      - 10.0.0.1
+      - 10.0.0.2

--- a/jobs/arbitrator/templates/garbd_config.erb
+++ b/jobs/arbitrator/templates/garbd_config.erb
@@ -2,6 +2,9 @@
   cluster_ips = []
   cluster_ips = link('mysql').instances.map { |instance| instance.address }
   cluster_ips += link('arbitrator').instances.map { |instance| instance.address }
+  if_p('cf_mysql.mysql.xtra_cluster_ips') do
+      cluster_ips += p('cf_mysql.mysql.xtra_cluster_ips')
+  end
 %>
 
 group = cf-mariadb-galera-cluster

--- a/jobs/bootstrap/spec
+++ b/jobs/bootstrap/spec
@@ -23,3 +23,8 @@ properties:
     default: galera-healthcheck
   cf_mysql.mysql.galera_healthcheck.endpoint_password:
     description: 'Password used to contact the sidecar endpoints via Basic Auth'
+  cf_mysql.mysql.xtra_cluster_ips:
+    description: 'additional cluster IPs that are not part of the deployment'
+    example: |
+      - 10.0.0.1
+      - 10.0.0.2

--- a/jobs/bootstrap/templates/config.yml.erb
+++ b/jobs/bootstrap/templates/config.yml.erb
@@ -4,6 +4,9 @@
   if_link('arbitrator') do |arb|
     cluster_ips += arb.instances.map { |instance| instance.address }
   end
+  if_p('cf_mysql.mysql.xtra_cluster_ips') do
+      cluster_ips += p('cf_mysql.mysql.xtra_cluster_ips')
+  end
   galera_healthcheck_port = mysql_link.p('cf_mysql.mysql.galera_healthcheck.port')
   galera_healthcheck_username = mysql_link.p('cf_mysql.mysql.galera_healthcheck.endpoint_username')
   galera_healthcheck_password = mysql_link.p('cf_mysql.mysql.galera_healthcheck.endpoint_password')

--- a/jobs/mysql/spec
+++ b/jobs/mysql/spec
@@ -196,6 +196,12 @@ properties:
   cf_mysql.mysql.cluster_health.password:
     description: 'Password for the cluster logger health user'
 
+  cf_mysql.mysql.xtra_cluster_ips:
+    description: 'additional cluster IPs that are not part of the deployment'
+    example: |
+      - 10.0.0.1
+      - 10.0.0.2
+
   cf_mysql.mysql.galera_healthcheck.endpoint_username:
     description: 'Username used by the sidecar endpoints for Basic Auth'
     default: galera-healthcheck

--- a/jobs/mysql/templates/mariadb_ctl_config.yml.erb
+++ b/jobs/mysql/templates/mariadb_ctl_config.yml.erb
@@ -22,6 +22,10 @@ def discover_external_ip
   if_link('arbitrator') do
     cluster_ips += link('arbitrator').instances.map(&:address)
   end
+
+  if_p('cf_mysql.mysql.xtra_cluster_ips') do
+    cluster_ips += p('cf_mysql.mysql.xtra_cluster_ips')
+  end
 %>
 
 LogFileLocation: /var/vcap/sys/log/mysql/mariadb_ctrl.combined.log

--- a/jobs/mysql/templates/my.cnf.erb
+++ b/jobs/mysql/templates/my.cnf.erb
@@ -6,6 +6,10 @@
     cluster_ips += link('arbitrator').instances.map { |instance| instance.address }
   end
 
+  if_p('cf_mysql.mysql.xtra_cluster_ips') do
+      cluster_ips += p('cf_mysql.mysql.xtra_cluster_ips')
+  end
+
   def discover_external_ip
     networks = spec.networks.marshal_dump
     _, network = networks.find do |_name, network_spec|


### PR DESCRIPTION
# Feature or Bug Description
Added new property to manually add cluster IPs  

# Motivation
This will allow the new mysql nodes join an existing cluster that are not part of the deployment (e.g. for migration)

# Related Issue
https://vdcbase.bskyb.com/nimbus/backlog-nimbus/-/issues/1383

